### PR TITLE
fix :if that did not work for me

### DIFF
--- a/lib/stimulus_reflex_profiler/flamegraph.rb
+++ b/lib/stimulus_reflex_profiler/flamegraph.rb
@@ -8,8 +8,12 @@ StimulusReflex::Reflex.class_eval do
 
     StimulusReflexProfiler::Flamegraph::Output.instance.content = html
   end
+
+  def flamegraph?
+    defined?(Flamegraph) && Flamegraph.respond_to?(:generate)
+  end
 end
 
 StimulusReflex::Reflex.class_exec do
-  set_callback :process, :around, :run_flamegraph, if: defined?(Flamegraph) && Flamegraph.respond_to?(:generate)
+  set_callback :process, :around, :run_flamegraph, if: :flamegraph?
 end


### PR DESCRIPTION
I was getting:

> undefined method `around' for true:TrueClass
> .../.rvm/gems/ruby-2.7.2/gems/activesupport-6.1.0/lib/active_support/callbacks.rb:427

with the current implementation of stimulus_reflex_profile. Looking at https://apidock.com/rails/v6.0.0/ActiveSupport/Callbacks/Callback/ClassMethods/set_callback , the if expects:

> if: A symbol or an array of symbols, each naming an instance method or a proc; the callback will be called only when they all return a true value.

The error message is weird though, I don't fully understand the issue. However, changing the `if` to use a symbol for a method and doing the conditional in the said method, resolved the problem.